### PR TITLE
fix(templates): remove px from width property

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
 		"test": "npx jest --watchAll",
 		"test:ci": "npx jest",
 		"qa": "npm-run-all clean --parallel lint test",
-		"build": "npm run clean && cross-env ELEVENTY_ENV=prod eleventy && ./bin/cli.mjs create"
+		"build": "npm run clean && cross-env ELEVENTY_ENV=prod eleventy && ./bin/cli.mjs create",
+		"build:local": "npm run build && npm run format && npm run test:ci"
 	},
 	"config": {
 		"commitizen": {

--- a/src/_data/theme.json
+++ b/src/_data/theme.json
@@ -20,10 +20,9 @@
 		"color": "#3c3532",
 		"link": "#0055aa"
 	},
-	"logoWidth": "150",
 	"padding": "15px 0px 20px 0px",
 	"size": {
-		"width": "600px",
+		"width": "600",
 		"content_padding": "15px 0px 20px 0px",
 		"wrapper_padding": "15px 20px"
 	},
@@ -32,5 +31,5 @@
 		"fontSize": "16px",
 		"lineHeight": "22px"
 	},
-	"width": "600px"
+	"width": "600"
 }


### PR DESCRIPTION
Asana Task: [Template width Outlook bug](https://app.asana.com/0/1207101853522549/1209103275427797/f)


Issue
---
Width is broken on the following device test:
1. Outlook 365 Dark (win10)
2. Outlook 2016 (win10)
3. Outlook 2016 120 DPI (win10)
4. Outlook 2019 (win10)
5. Outlook 2019 120 DPI


Solution
---
- Remove the `px` from `width` property in file `src/_data/theme.json` file.
- Add a new npm script `build:local` to test building local files in rapid development. 


Litmus Test
----
1. [Banner](https://litmus.com/folders/61444/emails/16472781/checklist)
7. [Event](https://litmus.com/folders/61444/emails/16472758/checklist)
8. [Letter](https://litmus.com/folders/61444/emails/16472789/checklist)
9. [Sidebox](https://litmus.com/folders/61444/emails/16472802/checklist)
10. [Fundraising](https://litmus.com/folders/61444/emails/16472805/checklist)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209102598704940